### PR TITLE
Convert functions to use sf objects instead of Spatial* objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,12 +17,13 @@ Imports:
     rgeos,
     sp,
     sf,
+    lwgeom,
     stats,
     urltools
 License: CC0
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Suggests: 
     knitr,
     ggplot2,

--- a/man/prepareTargetData.Rd
+++ b/man/prepareTargetData.Rd
@@ -12,7 +12,7 @@ prepareTargetData(
   aoi = "",
   crs = "",
   segments = 60,
-  returnType = "Spatial"
+  returnType = "sf"
 )
 }
 \arguments{
@@ -42,7 +42,7 @@ describing the area(s) of interest. Can be points or polygons.}
 reference system of \code{(x,y)} or \code{aoi}. \code{crs} is required when using
 \code{(x,y)}. It is optional when using \code{aoi}. This can also be a valid
 \code{SRS_string} for use with the sp::CRS() function where it will be provided
-as the \code{projargs} argument.}
+as the \code{projargs} argument. \code{crs} can also be an EPSG code (numeric).}
 
 \item{segments}{Number of segments to use when generating a circular
 area of interest. When using a \code{SpatialPoint*} or \code{sf} object

--- a/man/queryUSGSProjectIndex.Rd
+++ b/man/queryUSGSProjectIndex.Rd
@@ -14,11 +14,12 @@ queryUSGSProjectIndex(
   index = "",
   segments = 60,
   return = "index",
-  returnType = "Spatial",
+  returnType = "sf",
   returncrs = "same",
   lidarOnly = TRUE,
   dropNAColumns = NULL,
-  clean = TRUE,
+  clean = FALSE,
+  verbose = FALSE,
   ...
 )
 }
@@ -103,7 +104,8 @@ argument.}
 for the spatial overlay. For the USGS WESM index, setting \code{lidarOnly = TRUE}
 will include projects with the following values for the collection method:
 linear-mode lidar, Bathymetric LIDAR, Topobathymetric LIDAR, Geiger-mode LIDAR,
-Single Photon LIDAR. THIS OPTION IS NOT YET IMPLEMENTED.}
+Single Photon LIDAR. For other indexes, set \code{lidarOnly = FALSE} to prevent
+errors.}
 
 \item{dropNAColumns}{list of column names to test in the index for NA values.
 If any values in any of the columns are NA, the feature will be dropped
@@ -111,10 +113,17 @@ from the index prior to the spatial overlay. Default is to consider all
 features in the index.}
 
 \item{clean}{Boolean to enable a cleaning operation for the project polygons
-using a call to \code{gBuffer} with \code{width = 0} and \code{byid = TRUE}.
-This operation can fix many, but not all, topology problems. If you see
+using a call to \code{st_buffer} with \code{dist = 0}.
+This operation can fix some, but not all, topology problems. If you see
 warnings about self-intersecting rings, you may need to do some additional
-cleaning on a local copy of the project index.}
+cleaning on a local copy of the project index.
+As of 9/22/2021, I added some additional checks and removed the call to
+st_buffer. The operations invoked when \code{clean = TRUE} can take a long
+time so you may be better off loading the index and cleaning it outside
+of this library.}
+
+\item{verbose}{Boolean to enable printing of status messages. This is really
+only useful for code debugging.}
 
 \item{...}{Additional arguments passed to \code{download.file}}
 }
@@ -146,7 +155,6 @@ Finds all USGS lidar projects that cover the area-of-interest
 }
 \examples{
 \dontrun{
-queryUSGSProjectIndex(-13540901, 5806426, 180, shape = "circle",
-  crs = CRS(SRS_string="EPSG:3857"))
+queryUSGSProjectIndex(-13540901, 5806426, 180, shape = "circle", crs = 3857)
   }
 }

--- a/man/queryUSGSTileIndex.Rd
+++ b/man/queryUSGSTileIndex.Rd
@@ -8,7 +8,7 @@ queryUSGSTileIndex(
   x,
   y,
   buffer = 0,
-  projectID = "",
+  projectID = NULL,
   fieldname = "workunit_id",
   shape = "square",
   aoi = NULL,
@@ -16,8 +16,9 @@ queryUSGSTileIndex(
   index = "",
   segments = 60,
   return = "index",
-  returnType = "Spatial",
+  returnType = "sf",
   returncrs = "same",
+  verbose = FALSE,
   ...
 )
 }
@@ -40,7 +41,8 @@ units for \code{buffer} are always meters.}
 
 \item{projectID}{Character string or list of character strings
 containing the ID(s) for the lidar project(s). Typically obtained
-by calling queryUSGSProjectIndex().}
+by calling \code{queryUSGSProjectIndex()}. You must provide at least one
+project identifier.}
 
 \item{fieldname}{Character string containing the name of the field to
 use when querying the tile index.}
@@ -54,7 +56,8 @@ describing the area of interest. Can be points or polygons.}
 
 \item{crs}{Valid \code{proj4string} string defining the coordinate
 reference system of \code{(x,y)}. \code{crs} is required when using
-\code{(x,y)}. \code{crs} is ignored when \code{aoi} is specified.}
+\code{(x,y)}. \code{crs} is ignored when \code{aoi} is specified.
+\code{crs} can also be an EPSG code (numeric).}
 
 \item{index}{Index file for USGS lidar tiles If not provided, an index
 previously specified by a call to \code{fetchUSGSProjectIndex} or
@@ -92,6 +95,9 @@ reference system of the returned \code{SpatialPolygonsDataFrame} or
 to the same coordinate reference system as \code{aoi} or to \code{crs} when
 used with \code{(x,y)}.}
 
+\item{verbose}{Boolean to enable printing of status messages. This is really
+only useful for code debugging.}
+
 \item{...}{Additional arguments passed to \code{download.file}}
 }
 \value{
@@ -114,7 +120,6 @@ Query the tile index to find tiles that intersect the \code{buffer}ed
 }
 \examples{
 \dontrun{
-queryUSGSTileIndex(-13540901, 5806426, 180, shape = "circle",
-  CRS = CRS(SRS_string="EPSG:3857"))
+queryUSGSTileIndex(-13540901, 5806426, 180, shape = "circle", crs = 3857)
   }
 }

--- a/vignettes/my-vignette.Rmd
+++ b/vignettes/my-vignette.Rmd
@@ -57,6 +57,10 @@ is hosted [here](https://raw.githubusercontent.com/bmcgaughey1/EntwineIndex/main
 
 The example point is located within the 2014 Glacier Peak lidar acquisition in Washington state, USA.
 
+For the Entwine data collection, all data are from lidar so the lidarOnly option in queryUSGSProjectIndex
+is not needed. In addition, this option relies on a specific field in the USGS WESM index so it should
+only be used with indexes that include this field.
+
 **This example will download the [Entwine index](https://raw.githubusercontent.com/hobu/usgs-lidar/master/boundaries/resources.geojson) produced by Howard Butler into the current working directory.**
 
 ```{r fig.height=6, fig.width=6, message=FALSE, warning=FALSE}
@@ -69,7 +73,8 @@ project_polys <- queryUSGSProjectIndex(-13499097
                                        , 6139669
                                        , buffer = 500
                                        , shape = "circle"
-                                       , crs = "EPSG:3857"
+                                       , crs = 3857
+                                       , lidarOnly = FALSE
 )
 
 # now query to get the sample area attributed with the project polygon information
@@ -79,7 +84,8 @@ point_poly <- queryUSGSProjectIndex(-13499097
                                     , buffer = 500
                                     , shape = "circle"
                                     , return = "aoi"
-                                    , crs = "EPSG:3857"
+                                    , crs = 3857
+                                    , lidarOnly = FALSE
 )
 
 # finally, query using a point in UTM 10N within the same lidar acquisition to attribute
@@ -90,7 +96,8 @@ point <- queryUSGSProjectIndex(640377.7
                                 , shape = "circle"
                                 , return = "aoi"
                                 , crs = "EPSG:26910"
-                                , returncrs = "EPSG:3857"
+                                , returncrs = 3857
+                                , lidarOnly = FALSE
 )
 
 # display the project area polygon and the buffered point
@@ -102,7 +109,7 @@ ggplot() +
   annotation_spatial(point_poly, fill = "red")
 
 cat("Attributes for the acquistion in the ENTWINE index:\n",
-    paste(paste(colnames(project_polys@data), collapse= "\n "), "\n"))
+    paste(paste(colnames(project_polys), collapse= "\n "), "\n"))
 ```
 
 ## Example 2 -- Query USGS Entwine lidar collection using enhanced ENTWINE index
@@ -126,7 +133,7 @@ project_polys <- queryUSGSProjectIndex(-13499097
                                        , 6139669
                                        , buffer = 500
                                        , shape = "circle"
-                                       , crs = "EPSG:3857"
+                                       , crs = 3857
 )
 
 # now query to get the sample area attributed with the project polygon information
@@ -136,7 +143,7 @@ point_poly <- queryUSGSProjectIndex(-13499097
                                     , buffer = 500
                                     , shape = "circle"
                                     , return = "aoi"
-                                    , crs = "EPSG:3857"
+                                    , crs = 3857
 )
 
 # finally, query using a point in UTM 10N within the same lidar acquisition to attribute
@@ -146,8 +153,8 @@ point <- queryUSGSProjectIndex(640377.7
                                 , buffer = 0
                                 , shape = "circle"
                                 , return = "aoi"
-                                , crs = "EPSG:26910"
-                                , returncrs = "EPSG:3857"
+                                , crs = 26910
+                                , returncrs = 3857
 )
 
 # display the project area polygon and the buffered point
@@ -159,5 +166,5 @@ ggplot() +
   annotation_spatial(point_poly, fill = "red")
 
 cat("Attributes for the acquistion in the enhanced ENTWINE index:\n",
-    paste(paste(colnames(project_polys@data), collapse= "\n "), "\n"))
+    paste(paste(colnames(project_polys), collapse= "\n "), "\n"))
 ```


### PR DESCRIPTION
I worked on the code to change it to use sf objects instead of Spatial* objects within functions. This is to take advantage of some features not available with Spatial* objects and to generally update code as the sp package is replaced by the sf package. Code changes also simplify the use of projections and all the use of EPSG codes to specify projection information.